### PR TITLE
stock_vertical_lift_kardex: add missing dependency

### DIFF
--- a/stock_vertical_lift_kardex/__manifest__.py
+++ b/stock_vertical_lift_kardex/__manifest__.py
@@ -7,7 +7,7 @@
     "category": "Stock",
     "author": "Camptocamp, Odoo Community Association (OCA)",
     "license": "AGPL-3",
-    "depends": ["stock_vertical_lift"],
+    "depends": ["stock_vertical_lift", "stock_location_position"],
     "website": "https://www.camptocamp.com",
     "data": [],
     "installable": True,


### PR DESCRIPTION
we use the `level` field to materialize the tablar index -> this
field is provided by `stock_location_position`