### PR TITLE
[IMP] Fix naming of the shuttle address

### DIFF
--- a/stock_vertical_lift_kardex/models/stock_location.py
+++ b/stock_vertical_lift_kardex/models/stock_location.py
@@ -32,7 +32,9 @@ class StockLocation(models.Model):
         subst = {
             "code": code,
             "hostId": self.env["ir.sequence"].next_by_code("vertical.lift.command"),
-            "addr": shuttle.name,
+            # hard code the gate for now.
+            # TODO proper handling of multiple gates for 1 lift.
+            "addr": shuttle.name + '-1',
             "carrier": self.level,
             "carrierNext": "0",
             "x": x,

--- a/stock_vertical_lift_kardex/readme/ROADMAP.rst
+++ b/stock_vertical_lift_kardex/readme/ROADMAP.rst
@@ -1,1 +1,2 @@
 * Add support of the hardware
+* handle multiple gates for one lift


### PR DESCRIPTION
we hardcode the ID of the gate for now, hence we support
only a single gate.