### PR TITLE
stock_vertical_lift: make pkg compute more solid

### DIFF
--- a/stock_vertical_lift/models/vertical_lift_operation_base.py
+++ b/stock_vertical_lift/models/vertical_lift_operation_base.py
@@ -345,7 +345,7 @@ class VerticalLiftOperationTransfer(models.AbstractModel):
     @api.depends("current_move_line_id.product_id.packaging_ids")
     def _compute_product_packagings(self):
         for record in self:
-            product = record.mapped("current_move_line_id.product_id")
+            product = record.current_move_line_id.product_id
             if not product:
                 record.product_packagings = ""
                 continue

--- a/stock_vertical_lift/models/vertical_lift_operation_base.py
+++ b/stock_vertical_lift/models/vertical_lift_operation_base.py
@@ -229,6 +229,8 @@ class VerticalLiftOperationBase(models.AbstractModel):
         self.next_step()
 
     def _render_product_packagings(self, product):
+        if not product:
+            return ""
         return self.env["ir.qweb"].render(
             "stock_vertical_lift.packagings",
             self._prepare_values_for_product_packaging(product),
@@ -343,10 +345,10 @@ class VerticalLiftOperationTransfer(models.AbstractModel):
     @api.depends("current_move_line_id.product_id.packaging_ids")
     def _compute_product_packagings(self):
         for record in self:
-            if not record.current_move_line_id:
+            product = record.mapped("current_move_line_id.product_id")
+            if not product:
                 record.product_packagings = ""
                 continue
-            product = record.current_move_line_id.product_id
             content = self._render_product_packagings(product)
             record.product_packagings = content
 

--- a/stock_vertical_lift/models/vertical_lift_operation_inventory.py
+++ b/stock_vertical_lift/models/vertical_lift_operation_inventory.py
@@ -143,10 +143,10 @@ class VerticalLiftOperationInventory(models.Model):
     @api.depends("current_inventory_line_id.product_id.packaging_ids")
     def _compute_product_packagings(self):
         for record in self:
-            if not record.current_inventory_line_id:
+            product = record.mapped("current_inventory_line_id.product_id")
+            if not product:
                 record.product_packagings = ""
                 continue
-            product = record.current_inventory_line_id.product_id
             content = self._render_product_packagings(product)
             record.product_packagings = content
 

--- a/stock_vertical_lift/models/vertical_lift_operation_inventory.py
+++ b/stock_vertical_lift/models/vertical_lift_operation_inventory.py
@@ -143,7 +143,7 @@ class VerticalLiftOperationInventory(models.Model):
     @api.depends("current_inventory_line_id.product_id.packaging_ids")
     def _compute_product_packagings(self):
         for record in self:
-            product = record.mapped("current_inventory_line_id.product_id")
+            product = record.current_inventory_line_id.product_id
             if not product:
                 record.product_packagings = ""
                 continue


### PR DESCRIPTION
Somehow sometimes you can get a move line without product
while computing product packaging in inventory.

Make it more defensive and skip packaging rendering if no product is
there.